### PR TITLE
feat(cache-rules): add cache.conf editor UI & API with validation + ETag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,4 +15,4 @@ WAF_API_AUTH_DISABLE=
 
 VITE_CORAZA_API_BASE=http://localhost/mamotama-api
 VITE_APP_BASE_PATH=/mamotama-admin
-VITE_API_KEY=
+VITE_API_KEY=change-me

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ go.work.sum
 
 data/rules
 !data/rules/empty
+data/conf
+!data/conf/cache.conf
+!data/conf/waf.bypass

--- a/coraza/src/cmd/server/main.go
+++ b/coraza/src/cmd/server/main.go
@@ -38,6 +38,7 @@ func main() {
 					config.APIBasePath + "/logs",
 					config.APIBasePath + "/rules",
 					config.APIBasePath + "/bypass",
+					config.APIBasePath + "/cache-rules",
 				},
 			})
 		})
@@ -47,6 +48,9 @@ func main() {
 		api.GET("/rules", handler.RulesHandler)
 		api.GET("/bypass", handler.GetBypassHandler)
 		api.POST("/bypass", handler.SaveBypassHandler)
+		api.GET("/cache-rules", handler.GetCacheRules)
+		api.POST("/cache-rules:validate", handler.ValidateCacheRules)
+		api.PUT("/cache-rules", handler.PutCacheRules)
 	}
 
 	r.NoRoute(func(c *gin.Context) {

--- a/coraza/src/internal/cacheconf/api.go
+++ b/coraza/src/internal/cacheconf/api.go
@@ -1,0 +1,21 @@
+package cacheconf
+
+type Match struct {
+	Type  string `json:"type"`
+	Value string `json:"value"`
+}
+
+type RuleDTO struct {
+	Kind    string   `json:"kind"`
+	Match   Match    `json:"match"`
+	Methods []string `json:"methods,omitempty"`
+	TTL     int      `json:"ttl,omitempty"`
+	Vary    []string `json:"vary,omitempty"`
+}
+
+type RulesDTO struct {
+	ETag   string    `json:"etag"`
+	Raw    string    `json:"raw"`
+	Rules  []RuleDTO `json:"rules"`
+	Errors []string  `json:"errors"`
+}

--- a/coraza/src/internal/cacheconf/fileio.go
+++ b/coraza/src/internal/cacheconf/fileio.go
@@ -1,0 +1,61 @@
+package cacheconf
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+func AtomicWriteWithBackup(path string, data []byte) error {
+	if _, err := os.Stat(path); err == nil {
+		_ = copyFile(path, path+"."+time.Now().Format("20060102-150405")+".bak")
+	}
+
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".cache.conf.*")
+	if err != nil {
+		return err
+	}
+
+	tmpPath := tmp.Name()
+	_, werr := tmp.Write(data)
+	if werr != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return werr
+	}
+
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+
+	return os.Rename(tmpPath, path)
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+
+	defer out.Close()
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+
+	return out.Sync()
+}

--- a/coraza/src/internal/cacheconf/serialize.go
+++ b/coraza/src/internal/cacheconf/serialize.go
@@ -1,0 +1,163 @@
+package cacheconf
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+func ToDTO(rs *Ruleset) []RuleDTO {
+	if rs == nil {
+		return nil
+	}
+
+	out := make([]RuleDTO, 0, len(rs.Rules))
+	for _, r := range rs.Rules {
+		m := Match{}
+		switch {
+		case r.Exact != "":
+			m = Match{Type: "exact", Value: r.Exact}
+		case r.Prefix != "":
+			m = Match{Type: "prefix", Value: r.Prefix}
+		case r.Regex != nil:
+			m = Match{Type: "regex", Value: r.Regex.String()}
+		}
+		methods := make([]string, 0, len(r.Methods))
+		for k := range r.Methods {
+			methods = append(methods, strings.ToUpper(k))
+		}
+		if len(methods) == 0 {
+			methods = []string{"GET", "HEAD"}
+		} else {
+			sort.Strings(methods)
+		}
+		out = append(out, RuleDTO{
+			Kind:    strings.ToUpper(r.Kind),
+			Match:   m,
+			Methods: methods,
+			TTL:     r.TTL,
+			Vary:    r.Vary,
+		})
+	}
+
+	return out
+}
+
+func FromDTO(dtos []RuleDTO) (*Ruleset, []error) {
+	var errs []error
+	rs := &Ruleset{}
+	for i, d := range dtos {
+		r := Rule{Kind: strings.ToUpper(d.Kind), TTL: d.TTL, Vary: d.Vary}
+		if r.Kind != "ALLOW" && r.Kind != "DENY" {
+			errs = append(errs, fmt.Errorf("rules[%d]: kind must be ALLOW or DENY", i))
+		}
+
+		switch strings.ToLower(d.Match.Type) {
+		case "prefix":
+			if d.Match.Value == "" {
+				errs = append(errs, fmt.Errorf("rules[%d]: prefix value required", i))
+			}
+			r.Prefix = d.Match.Value
+		case "regex":
+			if d.Match.Value == "" {
+				errs = append(errs, fmt.Errorf("rules[%d]: regex value required", i))
+			} else {
+				re, err := regexp.Compile(d.Match.Value)
+				if err != nil {
+					errs = append(errs, fmt.Errorf("rules[%d]: invalid regex: %v", i, err))
+				} else {
+					r.Regex = re
+				}
+			}
+		case "exact":
+			if d.Match.Value == "" {
+				errs = append(errs, fmt.Errorf("rules[%d]: exact value required", i))
+			}
+			r.Exact = d.Match.Value
+		default:
+			errs = append(errs, fmt.Errorf("rules[%d]: match.type must be prefix|regex|exact", i))
+		}
+
+		r.Methods = map[string]bool{}
+		if len(d.Methods) == 0 {
+			r.Methods["GET"] = true
+			r.Methods["HEAD"] = true
+		} else {
+			for _, m := range d.Methods {
+				mu := strings.ToUpper(strings.TrimSpace(m))
+				if mu == "" {
+					continue
+				}
+				switch mu {
+				case "GET", "HEAD":
+					r.Methods[mu] = true
+				default:
+					errs = append(errs, fmt.Errorf("rules[%d]: unsupported method %q (only GET/HEAD)", i, mu))
+				}
+			}
+		}
+
+		if r.TTL < 0 {
+			errs = append(errs, fmt.Errorf("rules[%d]: ttl must be >= 0", i))
+		}
+
+		rs.Rules = append(rs.Rules, r)
+	}
+
+	if len(errs) > 0 {
+		return nil, errs
+	}
+
+	return rs, nil
+}
+
+func RulesetToLines(rs *Ruleset) []string {
+	if rs == nil {
+		return nil
+	}
+
+	lines := make([]string, 0, len(rs.Rules))
+	for _, r := range rs.Rules {
+		parts := []string{strings.ToUpper(r.Kind)}
+		if r.Exact != "" {
+			parts = append(parts, "exact="+r.Exact)
+		}
+
+		if r.Prefix != "" {
+			parts = append(parts, "prefix="+r.Prefix)
+		}
+
+		if r.Regex != nil {
+			parts = append(parts, "regex="+r.Regex.String())
+		}
+
+		if len(r.Methods) > 0 {
+			ms := make([]string, 0, len(r.Methods))
+			for k := range r.Methods {
+				ms = append(ms, strings.ToUpper(k))
+			}
+			sort.Strings(ms)
+			parts = append(parts, "methods="+strings.Join(ms, ","))
+		}
+
+		if r.TTL > 0 {
+			parts = append(parts, fmt.Sprintf("ttl=%d", r.TTL))
+		}
+
+		if len(r.Vary) > 0 {
+			parts = append(parts, "vary="+strings.Join(r.Vary, ","))
+		}
+
+		lines = append(lines, strings.Join(parts, " "))
+	}
+
+	return lines
+}
+
+func ComputeETag(b []byte) string {
+	h := sha256.Sum256(b)
+	return `W/"sha256:` + hex.EncodeToString(h[:]) + `"`
+}

--- a/coraza/src/internal/handler/cache_rules.go
+++ b/coraza/src/internal/handler/cache_rules.go
@@ -1,0 +1,114 @@
+package handler
+
+import (
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"mamotama/internal/cacheconf"
+)
+
+const cacheConfPath = "conf/cache.conf"
+
+type crPutBody struct {
+	RawMode bool                `json:"rawMode"`
+	Raw     string              `json:"raw"`
+	Rules   []cacheconf.RuleDTO `json:"rules"`
+}
+
+func GetCacheRules(c *gin.Context) {
+	raw, _ := os.ReadFile(cacheConfPath)
+	rs := cacheconf.Get()
+	dto := cacheconf.RulesDTO{
+		ETag:  cacheconf.ComputeETag(raw),
+		Raw:   string(raw),
+		Rules: cacheconf.ToDTO(rs),
+	}
+
+	c.JSON(http.StatusOK, dto)
+}
+
+func ValidateCacheRules(c *gin.Context) {
+	var in crPutBody
+	if err := c.ShouldBindJSON(&in); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	if in.RawMode {
+		if _, err := cacheconf.LoadFromBytes([]byte(in.Raw)); err != nil {
+			c.JSON(http.StatusUnprocessableEntity, gin.H{"ok": false, "messages": []string{err.Error()}})
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{"ok": true, "messages": []string{}})
+		return
+	}
+
+	if _, errs := cacheconf.FromDTO(in.Rules); len(errs) > 0 {
+		msgs := make([]string, 0, len(errs))
+		for _, e := range errs {
+			msgs = append(msgs, e.Error())
+		}
+
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"ok": false, "messages": msgs})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"ok": true, "messages": []string{}})
+}
+
+func PutCacheRules(c *gin.Context) {
+	ifMatch := c.GetHeader("If-Match")
+	curRaw, _ := os.ReadFile(cacheConfPath)
+	curETag := cacheconf.ComputeETag(curRaw)
+	if ifMatch != "" && ifMatch != curETag {
+		c.JSON(http.StatusConflict, gin.H{"error": "conflict", "currentETag": curETag})
+		return
+	}
+
+	var in crPutBody
+	if err := c.ShouldBindJSON(&in); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	var outBytes []byte
+	if in.RawMode {
+		if _, err := cacheconf.LoadFromBytes([]byte(in.Raw)); err != nil {
+			c.JSON(http.StatusUnprocessableEntity, gin.H{"ok": false, "messages": []string{err.Error()}})
+			return
+		}
+
+		outBytes = []byte(in.Raw)
+	} else {
+		rs, errs := cacheconf.FromDTO(in.Rules)
+		if len(errs) > 0 {
+			msgs := make([]string, 0, len(errs))
+			for _, e := range errs {
+				msgs = append(msgs, e.Error())
+			}
+			c.JSON(http.StatusUnprocessableEntity, gin.H{"ok": false, "messages": msgs})
+			return
+		}
+
+		header := []string{
+			"# cache.conf - Mamotama Cache Rules",
+			"# Top-down evaluation; first match wins.",
+			"# Syntax: ALLOW|DENY prefix=...|regex=...|exact=... methods=GET,HEAD ttl=<sec> vary=Header,Header",
+			"",
+		}
+		lines := cacheconf.RulesetToLines(rs)
+		out := append(header, lines...)
+		outBytes = []byte(strings.Join(out, "\n") + "\n")
+	}
+
+	if err := cacheconf.AtomicWriteWithBackup(cacheConfPath, outBytes); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	newETag := cacheconf.ComputeETag(outBytes)
+	c.JSON(http.StatusOK, gin.H{"ok": true, "etag": newETag})
+}

--- a/data/conf/cache.conf
+++ b/data/conf/cache.conf
@@ -1,20 +1,7 @@
 # cache.conf - Mamotama Cache Rules
-# ---------------------------------
-# 記述順に評価され、最初にマッチしたルールが適用されます。
-# ALLOW: キャッシュ許可 / DENY: キャッシュ禁止
-# プレフィックス・正規表現・完全一致いずれかを指定します。
+# Top-down evaluation; first match wins.
+# Syntax: ALLOW|DENY prefix=...|regex=...|exact=... methods=GET,HEAD ttl=<sec> vary=Header,Header
 
-# ---------------------------------
-# 静的アセット（CSS/JS/画像）を10分キャッシュ
 ALLOW prefix=/_next/static/chunks/ methods=GET,HEAD ttl=600 vary=Accept-Encoding
-
-# ドキュメントHTMLは5分
 ALLOW regex=^/about/.*\.html$ methods=GET ttl=300
-
-# API全域禁止（安全側）
-DENY  prefix=/mamotama-api/
-
-# 認証ユーザーのプロフィールはキャッシュ禁止
-DENY  regex=^/users/[0-9]+/profile
-
-# その他はデフォルトでキャッシュ禁止
+DENY prefix=/mamotama-api/ methods=GET,HEAD ttl=600

--- a/web/mamotama-admin/src/App.tsx
+++ b/web/mamotama-admin/src/App.tsx
@@ -5,6 +5,7 @@ import Logs from './pages/Logs';
 import Rules from './pages/Rules';
 import Settings from './pages/Settings';
 import BypassEditor from './pages/BypassEditor';
+import CacheRulePanel from './pages/CacheRulesPanel';
 
 function App() {
   return (
@@ -16,6 +17,7 @@ function App() {
           <Route path="logs" element={<Logs />} />
           <Route path="rules" element={<Rules />} />
           <Route path="bypass" element={<BypassEditor />} />
+          <Route path="cache" element={<CacheRulePanel />} />
           <Route path="settings" element={<Settings />} />
         </Route>
       </Routes>

--- a/web/mamotama-admin/src/components/Layout.tsx
+++ b/web/mamotama-admin/src/components/Layout.tsx
@@ -12,6 +12,7 @@ export default function Layout() {
           <Link to="/logs" className={pathname === '/logs' ? 'font-bold' : ''}>Logs</Link>
           <Link to="/rules" className={pathname === '/rules' ? 'font-bold' : ''}>Rules</Link>
           <Link to="/bypass" className={pathname === '/bypass' ? 'font-bold' : ''}>Bypass</Link>
+          <Link to="/cache" className={pathname === '/cache' ? 'font-bold' : ''}>Cache</Link>
           <Link to="/settings" className={pathname === '/settings' ? 'font-bold' : ''}>Settings</Link>
         </nav>
       </aside>

--- a/web/mamotama-admin/src/lib/api.ts
+++ b/web/mamotama-admin/src/lib/api.ts
@@ -60,3 +60,45 @@ export async function apiPostText(path: string, body: string, init: RequestInit 
 
     return res;
 }
+
+export async function apiPostJson<T = any>(path: string, body: unknown, init: RequestInit = {}) {
+    const headers = new Headers(init.headers || {});
+    headers.set("Content-Type", "application/json");
+    withKey(headers)
+
+    const res = await fetch(`${API_BASE}${path}`, {
+        method: "POST",
+        body: JSON.stringify(body),
+        ...init,
+        headers,
+        credentials: "include",
+    });
+
+    const data = await res.json().catch(() => ({}));
+    if (! res.ok) {
+        throw new Error((data as any)?.error || `HTTP ${res.status}`);
+    }
+
+    return data as T;
+}
+
+export async function apiPutJson<T = any>(path: string, body: unknown, init: RequestInit = {}) {
+    const headers = new Headers(init.headers ||{});
+    headers.set("Content-Type", "application/json");
+    withKey(headers);
+
+    const res = await fetch(`${API_BASE}${path}`, {
+        method: "PUT",
+        body: JSON.stringify(body),
+        ...init,
+        headers,
+        credentials: "include",
+    });
+
+    const data = await res.json().catch(() => ({}));
+    if (! res.ok) {
+        throw new Error((data as any)?.error ||`HTTP ${res.status}`);
+    }
+
+    return data as T;
+}

--- a/web/mamotama-admin/src/pages/CacheRulesPanel.tsx
+++ b/web/mamotama-admin/src/pages/CacheRulesPanel.tsx
@@ -1,0 +1,213 @@
+import { useEffect, useState } from "react";
+import { apiGetJson, apiPostJson, apiPutJson } from "@/lib/api";
+
+type Match = { type: "prefix" | "regex" | "exact"; value: string };
+type Rule = {
+    kind: "ALLOW" | "DENY";
+    match: Match;
+    methods?: string[];
+    ttl?: number;
+    vary?: string[];
+};
+type RulesDTO = {
+    etag: string;
+    raw: string;
+    rules: Rule[];
+    errors?: string[];
+};
+
+export default function CacheRulePanel() {
+    const [rules, setRules] = useState<Rule[]>([]);
+    const [raw, setRaw] = useState("");
+    const [rawMode, setRawMode] = useState(false);
+    const [etag, setEtag] = useState("");
+    const [loading, setLoading] = useState(false);
+    const [msgs, setMsgs] = useState<string[]>([]);
+
+    useEffect(() => {
+        void reload(); 
+    }, []);
+
+    async function reload() {
+        setLoading(true);
+        setMsgs([]);
+
+        try {
+            const { etag, rules, raw } = await apiGetJson<RulesDTO>("/cache-rules");
+            setRules(rules ?? []);
+            setRaw(raw ?? "");
+            setEtag(etag ?? "");
+        } catch (e: any) {
+            setMsgs([e?.message || "ロードに失敗"]);
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    function update(i: number, v: Rule) {
+        setRules(rs => rs.map((r, idx) => (idx === i ? v : r)));
+    }
+
+    function remove(i: number) {
+        setRules(rs => rs.filter((_, idx) => idx !== i));
+    }
+
+    function addRule() {
+        setRules(r => [
+            ...r,
+            {
+                kind: "ALLOW",
+                match: {
+                    type: "prefix",
+                    value: "/"
+                },
+                methods: [
+                    "GET", "HEAD"
+                ],
+                ttl: 600,
+                vary: ["Accept-Encoding"]
+            },
+        ]);
+    }
+
+    async function validate() {
+        setMsgs([]);
+        const body = rawMode ? { rawMode: true, raw } : { rawMode: false, rules };
+
+        try {
+            const js = await apiPostJson<{ ok: Boolean; messages?: string[] }>("/cache-rules:validate", body);
+            if (! js.ok) {
+                setMsgs(js.messages ?? ["validation error"]);
+            } else {
+                setMsgs(["OK"]);
+            }
+        } catch (e: any) {
+            setMsgs([e?.message || "validate failed"]);
+        }
+    }
+
+    async function save() {
+        setMsgs([]);
+        const body = rawMode ? { rawMode: true, raw } : { rawMode: false, rules };
+
+        try {
+            const js = await apiPutJson<{ ok: Boolean; etag?: string }>("/cache-rules", body, {
+                headers: {
+                    "If-Match": etag
+                },
+            });
+
+            if (! js.ok) {
+                throw new Error("save failed");
+            }
+
+            setEtag(js.etag ?? "");
+            setMsgs(["保存しました。ホットリロードで即時反映されます。"]);
+        } catch (e: any) {
+            setMsgs([e?.message || "save failed"]);
+        }
+    }
+
+    return (
+        <div className="p-4 space-y-3">
+            <div className="flex items-center gap-3">
+                <h2 className="text-lg font-semibold">Cache Rules</h2>
+                <label className="flex items-center gap-1">
+                <input type="checkbox" checked={rawMode} onChange={e => setRawMode(e.target.checked)} />
+                Raw 編集
+                </label>
+                <button onClick={reload} disabled={loading} className="px-3 py-1 border rounded">Reload</button>
+                <button onClick={validate} disabled={loading} className="px-3 py-1 border rounded">Validate</button>
+                <button onClick={save} disabled={loading} className="px-3 py-1 border rounded">Save</button>
+            </div>
+
+            {! rawMode ? (
+                <div className="space-y-2">
+                <button onClick={addRule} className="px-2 py-1 border rounded">ルール追加</button>
+                <div className="overflow-x-auto">
+                    <table className="min-w-[800px] w-full text-sm border">
+                    <thead>
+                        <tr className="bg-neutral-900/20">
+                        <th className="p-2 border">Kind</th>
+                        <th className="p-2 border">Match Type</th>
+                        <th className="p-2 border">Value</th>
+                        <th className="p-2 border">Methods</th>
+                        <th className="p-2 border">TTL(s)</th>
+                        <th className="p-2 border">Vary</th>
+                        <th className="p-2 border w-24"></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {rules.map((r, i) => (
+                        <tr key={i}>
+                            <td className="p-1 border">
+                            <select value={r.kind} onChange={e => update(i, { ...r, kind: e.target.value as any })} className="w-full">
+                                <option>ALLOW</option>
+                                <option>DENY</option>
+                            </select>
+                            </td>
+                            <td className="p-1 border">
+                            <select
+                                value={r.match.type}
+                                onChange={e => update(i, { ...r, match: { ...r.match, type: e.target.value as any } })}
+                                className="w-full"
+                            >
+                                <option>prefix</option>
+                                <option>regex</option>
+                                <option>exact</option>
+                            </select>
+                            </td>
+                            <td className="p-1 border">
+                            <input className="w-full" value={r.match.value} onChange={e => update(i, { ...r, match: { ...r.match, value: e.target.value } })} />
+                            </td>
+                            <td className="p-1 border">
+                            <input
+                                className="w-full"
+                                value={(r.methods ?? []).join(",")}
+                                onChange={e => update(i, { ...r, methods: e.target.value.split(",").map(s => s.trim()).filter(Boolean) })}
+                                placeholder="GET,HEAD"
+                            />
+                            </td>
+                            <td className="p-1 border">
+                            <input
+                                type="number"
+                                className="w-full"
+                                value={r.ttl ?? 0}
+                                onChange={e => update(i, { ...r, ttl: Number.isFinite(+e.target.value) ? parseInt(e.target.value || "0", 10) : 0 })}
+                            />
+                            </td>
+                            <td className="p-1 border">
+                            <input
+                                className="w-full"
+                                value={(r.vary ?? []).join(",")}
+                                onChange={e => update(i, { ...r, vary: e.target.value.split(",").map(s => s.trim()).filter(Boolean) })}
+                                placeholder="Accept-Encoding,Accept-Language"
+                            />
+                            </td>
+                            <td className="p-1 border text-center">
+                            <button onClick={() => remove(i)} className="px-2 py-1 border rounded">削除</button>
+                            </td>
+                        </tr>
+                        ))}
+                        {rules.length === 0 && (
+                        <tr>
+                            <td colSpan={7} className="p-3 text-center text-neutral-400">ルールがありません</td>
+                        </tr>
+                        )}
+                    </tbody>
+                    </table>
+                </div>
+                </div>
+            ) : (
+                <textarea className="w-full h-96 font-mono p-2 border rounded" value={raw} onChange={e => setRaw(e.target.value)} />
+            )}
+
+            {msgs.length > 0 && (
+                <div className="border p-2">
+                {msgs.map((m, i) => (<div key={i}>{m}</div>))}
+                </div>
+            )}
+        </div>
+    );
+}
+


### PR DESCRIPTION
- Admin UI
  - Add CacheRulesPanel (table/raw edit, Validate, Save).
  - Wire through api.ts; add apiPostJson/apiPutJson helpers; unify all calls.

- API (Go/Gin)
  - Add /mamotama-api/cache-rules (GET) to return {etag, raw, rules}.
  - Add /mamotama-api/cache-rules:validate (POST) for dry-run validation.
  - Add /mamotama-api/cache-rules (PUT) with If-Match (ETag) for optimistic locking.
  - Atomic write with backup when saving cache.conf; hot-reload picks changes.

- cacheconf
  - Implement LoadFromString/LoadFromBytes and a shared parser.
  - Add DTO conversion, ETag computation, and text serialization helpers.
  - Fix compile issues (remove unused var, resolve undefined LoadFromString).

- Router
  - Register the three cache-rules endpoints (GET/POST:validate/PUT).

- Docs
  - Update README: API list, cache-rules usage (curl examples).
  - Adjust “Environment Variables” section to match current .env/nginx.

Security:
- Requires X-API-Key (primary/secondary supported); API paths remain no-cache.

Test Plan:
1) GET /mamotama-api/cache-rules and note ETag.
2) POST /mamotama-api/cache-rules:validate with sample rules → ok=true. 3) PUT /mamotama-api/cache-rules with If-Match → returns new etag; rules applied. 4) Verify headers (X-Mamotama-Cacheable, X-Accel-Expires) and nginx X-Cache-Status. 5) Conflict case: reuse old ETag → 409 expected.

Refs: feature/0.4.2/add-cache-rules-editor